### PR TITLE
Make headers compatible w/ non-ARC projects

### DIFF
--- a/AppboyKit/headers/AppboyKitLibrary/ABKCard.h
+++ b/AppboyKit/headers/AppboyKitLibrary/ABKCard.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
  * This property carries extra data in the form of an NSDictionary which can be sent down via the Appboy Dashboard.
  * You may want to design and implement a custom handler to access this data depending on your use case.
  */
-@property (nullable) NSDictionary *extras;
+@property (strong, nullable) NSDictionary *extras;
 
 /*
  * @param cardDictionary The dictionary for card deserialization.`

--- a/AppboyKit/headers/AppboyKitLibrary/ABKFeedViewControllerModalContext.h
+++ b/AppboyKit/headers/AppboyKitLibrary/ABKFeedViewControllerModalContext.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ABKFeedViewControllerModalContext : ABKFeedViewControllerGenericContext
 
 /*! Title displayed in the top bar */
-@property (nullable) NSString *navigationBarTitle;
+@property (strong, nullable) NSString *navigationBarTitle;
 
 /*! Delegate */
 @property (weak, nullable) id<ABKFeedViewControllerModalContextDelegate> closeButtonDelegate;

--- a/AppboyKit/headers/AppboyKitLibrary/ABKFeedViewControllerPopoverContext.h
+++ b/AppboyKit/headers/AppboyKitLibrary/ABKFeedViewControllerPopoverContext.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ABKFeedViewControllerPopoverContext : ABKFeedViewControllerGenericContext
 
 /*! Title displayed in the top bar */
-@property (nullable) NSString *navigationBarTitle;
+@property (strong, nullable) NSString *navigationBarTitle;
 
 /*! Delegate */
 @property (weak, nullable) id<ABKFeedViewControllerPopoverContextDelegate> closeButtonDelegate;

--- a/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessage.h
+++ b/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessage.h
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
  * This property carries extra data in the form of an NSDictionary which can be sent down via the Appboy Dashboard.
  * You may want to design and implement a custom handler to access this data depending on your use-case.
  */
-@property (nullable) NSDictionary *extras;
+@property (strong, nullable) NSDictionary *extras;
 
 /*!
  * This property defines the number of seconds before the in-app message is automatically dismissed.
@@ -87,12 +87,12 @@ NS_ASSUME_NONNULL_BEGIN
  * backgroundColor defines the background color of the in-app message. The default background color is black with 0.9 alpha for
  * ABKInAppMessageSlideup, and white with 1.0 alpha for ABKInAppMessageModal and ABKInAppMessageFull.
  */
-@property (nullable) UIColor *backgroundColor;
+@property (strong, nullable) UIColor *backgroundColor;
 
 /*!
  * textColor defines the message text color of the in-app message. The default text color is black.
  */
-@property (nullable) UIColor *textColor;
+@property (strong, nullable) UIColor *textColor;
 
 /*!
  * icon defines the font awesome unicode string of the Appboy icon.
@@ -105,13 +105,13 @@ NS_ASSUME_NONNULL_BEGIN
  * iconColor defines the font color of icon property.
  * The default font color is white.
  */
-@property (nullable) UIColor *iconColor;
+@property (strong, nullable) UIColor *iconColor;
 
 /*!
  * iconBackgroundColor defines the background color of icon property.
  *  * The default background color's RGB values are R:0 G:115 B:213.
  */
-@property (nullable) UIColor *iconBackgroundColor;
+@property (strong, nullable) UIColor *iconBackgroundColor;
 
 /*!
  * imageURI defines the URI of the image icon on in-app message.

--- a/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageButton.h
+++ b/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageButton.h
@@ -15,13 +15,13 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  * This property defines the button's background color.
  */
-@property (nonatomic, nullable) UIColor *buttonBackgroundColor;
+@property (nonatomic, strong, nullable) UIColor *buttonBackgroundColor;
 
 /*!
  * This property defines the button's title color in UIControlStateNormal. Setting this property will also change the
  * button title color.
  */
-@property (nonatomic, nullable) UIColor *buttonTextColor;
+@property (nonatomic, strong, nullable) UIColor *buttonTextColor;
 
 /*!
  * This property defines the action that will be performed when the button is clicked.

--- a/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageHTML.h
+++ b/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageHTML.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  * This property is the remote URL of the assets zip file.
  */
-@property (nullable) NSURL *assetsZipRemoteUrl;
+@property (strong, nullable) NSURL *assetsZipRemoteUrl;
 
 /*!
  * Log a click on the in-app message with a buttonID. Clicks may only be logged once per in-app message.

--- a/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageHTMLViewController.h
+++ b/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageHTMLViewController.h
@@ -5,7 +5,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface ABKInAppMessageHTMLViewController : ABKInAppMessageViewController <UIWebViewDelegate>
 
-@property IBOutlet UIWebView *webView;
+@property (weak) IBOutlet UIWebView *webView;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageImmersive.h
+++ b/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageImmersive.h
@@ -19,13 +19,13 @@ NS_ASSUME_NONNULL_BEGIN
  * headerTextColor defines the header text color, when there is a header string in the in-app message. The default text color
  * is black.
  */
-@property (nullable) UIColor *headerTextColor;
+@property (strong, nullable) UIColor *headerTextColor;
 
 /*!
  * closeButtonColor defines the close button color of the in-app message.
  * When this property is nil, the close button's default color is black.
  */
-@property (nullable) UIColor *closeButtonColor;
+@property (strong, nullable) UIColor *closeButtonColor;
 
 /*!
  * buttons defines the buttons of the in-app message.

--- a/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageImmersiveViewController.h
+++ b/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageImmersiveViewController.h
@@ -8,7 +8,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface ABKInAppMessageImmersiveViewController : ABKInAppMessageViewController
 
-@property IBOutlet ABKLabel *inAppMessageHeaderLabel;
+@property (weak) IBOutlet ABKLabel *inAppMessageHeaderLabel;
 
 - (IBAction) dismissInAppMessage:(id)sender;
 @end

--- a/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageModal.h
+++ b/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageModal.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
  * screen outside of modal in-app message. When the property is nil, the color will be
  * set to the default color, which is black with 90% opacity.
  */
-@property (nullable) UIColor *modalFrameColor;
+@property (strong, nullable) UIColor *modalFrameColor;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageSlideup.h
+++ b/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageSlideup.h
@@ -37,6 +37,6 @@ NS_ASSUME_NONNULL_BEGIN
  * chevronColor defines the chevron arrow color of the in-app message.
  * When this property is nil, the chevron's default color is white.
  */
-@property (nullable) UIColor *chevronColor;
+@property (strong, nullable) UIColor *chevronColor;
 @end
 NS_ASSUME_NONNULL_END

--- a/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageSlideupViewController.h
+++ b/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageSlideupViewController.h
@@ -8,7 +8,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface ABKInAppMessageSlideupViewController : ABKInAppMessageViewController
 
-@property (nullable) IBOutlet UIImageView *arrowImage;
+@property (weak, nullable) IBOutlet UIImageView *arrowImage;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageViewController.h
+++ b/AppboyKit/headers/AppboyKitLibrary/ABKInAppMessageViewController.h
@@ -22,10 +22,10 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface ABKInAppMessageViewController : UIViewController
 
-@property ABKInAppMessage *inAppMessage;
-@property IBOutlet UIImageView *iconImageView;
-@property IBOutlet UILabel *iconLabelView;
-@property IBOutlet ABKLabel *inAppMessageMessageLabel;
+@property (strong) ABKInAppMessage *inAppMessage;
+@property (weak) IBOutlet UIImageView *iconImageView;
+@property (weak) IBOutlet UILabel *iconLabelView;
+@property (weak) IBOutlet ABKLabel *inAppMessageMessageLabel;
 
 /*
  * The initWithInAppMessage method may be used to pass the inAppMessage property to any custom view controller that you create.

--- a/AppboyKit/headers/AppboyKitLibrary/ABKUser.h
+++ b/AppboyKit/headers/AppboyKitLibrary/ABKUser.h
@@ -100,18 +100,18 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  * The User's Facebook account information. For more detail, please refer to ABKFacebookUser.h.
  */
-@property (nullable) ABKFacebookUser *facebookUser;
+@property (strong, nullable) ABKFacebookUser *facebookUser;
 
 /*!
  * The User's Twitter account information. For more detail, please refer to ABKTwitterUser.h.
  */
-@property (nullable) ABKTwitterUser *twitterUser;
+@property (strong, nullable) ABKTwitterUser *twitterUser;
 
 /*!
  * Sets the attribution information for the user. For in apps that have an install tracking integration.
  * For more information, please refer to ABKAttributionData.h.
  */
-@property (nullable) ABKAttributionData *attributionData;
+@property (strong, nullable) ABKAttributionData *attributionData;
 
 /* ------------------------------------------------------------------------------------------------------
  * Enums


### PR DESCRIPTION
Gets rid of a bunch of build warnings when these headers are imported in a non-ARC project
```
No 'assign', 'retain', or 'copy' attribute is specified - 'assign' is assumed
Default property attribute 'assign' not appropriate for non-GC object
```