### PR TITLE
Update specs to require SDWebImage 4.0.x to resolve SDWebImage out of…

### DIFF
--- a/Appboy-iOS-SDK.podspec
+++ b/Appboy-iOS-SDK.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.resource = 'AppboyKit/Appboy.bundle'
   s.preserve_paths = 'AppboyKit/**/*.*'
   s.vendored_libraries = 'AppboyKit/libAppboyKitLibrary.a'
-  s.dependency 'SDWebImage', '~>3.7'
+  s.dependency 'SDWebImage', '~>4.0'
 end


### PR DESCRIPTION
We just encounter issue when integrate SDWebImage, which conflict version with your version required.