### PR TITLE
Silence warning when building for iOS 10+

### DIFF
--- a/AppboyKit/headers/AppboyKitLibrary/ABKPushUtils.h
+++ b/AppboyKit/headers/AppboyKitLibrary/ABKPushUtils.h
@@ -103,7 +103,10 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)shouldFetchTestTriggersFlagContainedInPayload:(NSDictionary *)userInfo __deprecated;
 
 + (NSSet<UNNotificationCategory *> *)getAppboyUNNotificationCategorySet;
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < 10
 + (NSSet<UIUserNotificationCategory *> *)getAppboyUIUserNotificationCategorySet;
+#endif
 
 @end
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
The iOS 10-safe method has already been implemented, but for Xcode not to complain the pre-iOS 10 method (using `UIUserNotificationCategory`) needs to not be compiled.