### PR TITLE
statusBarHidden support for custom InAppMessage ViewController

### DIFF
--- a/AppboyUI/InAppMessage/ViewControllers/ABKInAppMessageWindowController.m
+++ b/AppboyUI/InAppMessage/ViewControllers/ABKInAppMessageWindowController.m
@@ -97,6 +97,12 @@ static CGFloat const MinimumInAppMessageDismissVelocity = 20.0;
   return [UIApplication sharedApplication].statusBarOrientation;;
 }
 
+#pragma mark - StatusBar
+
+-(UIViewController *) childViewControllerForStatusBarHidden {
+    return self.inAppMessageViewController;
+}
+
 #pragma mark - Gesture Recognizers
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {


### PR DESCRIPTION
We need support to set the preferredStatusbarHidden attribute via code (not in the Info.plist), which results in InAppMessage showing the status bar. The patch would enable custom InAppMessage ViewControllers to manage status bar for InAppMessages displayed.

Maybe it makes sense to add the following code to the  ABKInAppMessageViewController implementation, to copy the current prefersStatusBarHidden of the topmostViewController displayed.

```
#pragma mark - Status Bar

-(BOOL) prefersStatusBarHidden {
    UIViewController *rootViewController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
    return [[ABKUIURLUtils topmostViewControllerWithRootViewController:rootViewController] prefersStatusBarHidden];
}
```