### PR TITLE
Fixing Portuguese News Feed Strings on smaller devices

### DIFF
--- a/AppboyUI/ABKFeedViewController/Feed_Resources/pt.lproj/AppboyFeedLocalizable.strings
+++ b/AppboyUI/ABKFeedViewController/Feed_Resources/pt.lproj/AppboyFeedLocalizable.strings
@@ -2,6 +2,6 @@
 "Appboy.feed.card.cross-promotion.price.free" = "Gratuito";
 "Appboy.feed.card.cross-promotion.price.format" = "$%.2f";
 "Appboy.feed.done-button.title" = "Concluído";
-"Appboy.feed.no-card.text" = "Não temos nenhuma atualização. Verifique novamente mais tarde.";
+"Appboy.feed.no-card.text" = "Não temos nenhuma atualização.\nVerifique novamente mais tarde.";
 "Appboy.feed.no-connection.title" = "Erro de conexão";
-"Appboy.feed.no-connection.message" = "Não é possível estabelecer uma conexão de rede. Tente novamente mais tarde.";
+"Appboy.feed.no-connection.message" = "Não foi possível estabelecer uma\nconexão. Tente novamente mais tarde.";


### PR DESCRIPTION
This adds line breaks for the Portuguese News Feed strings, which don't fit smaller devices currently.

I've also changed the spelling on the connection message, as it was too literal and hard to fit on an iPhone 5.