### PR TITLE
Fix subclassing issue of ABKInAppMessageModalViewController

### DIFF
--- a/AppboyUI/InAppMessage/ViewControllers/ABKInAppMessageModalViewController.m
+++ b/AppboyUI/InAppMessage/ViewControllers/ABKInAppMessageModalViewController.m
@@ -114,7 +114,7 @@ static const CGFloat MaxModalViewGraphicSize = 290.0f;
 }
 
 - (void)viewDidLayoutSubviews {
-  if ([self isMemberOfClass:[ABKInAppMessageModalViewController class]]) {
+  if ([self isKindOfClass:[ABKInAppMessageModalViewController class]]) {
     if (self.textsView && !self.textsViewWidthConstraint) {
       [self.view layoutIfNeeded];
       NSLayoutConstraint *widthConstraint = [NSLayoutConstraint constraintWithItem:self.textsView


### PR DESCRIPTION
Replace isMemberOfClass by isKindOfClass so subclass can inherit viewDidLayoutSubviews.