### PR TITLE
Fix logic validating cache's timeout

### DIFF
--- a/AppboyUI/ABKFeedViewController/FeedViewController/ABKNewsFeedTableViewController.m
+++ b/AppboyUI/ABKFeedViewController/FeedViewController/ABKNewsFeedTableViewController.m
@@ -92,7 +92,7 @@
 }
 
 - (void)requestNewCardsIfTimeout {
-  NSTimeInterval passedTime = [[Appboy sharedInstance].feedController.lastUpdate timeIntervalSinceNow];
+  NSTimeInterval passedTime = fabs([[Appboy sharedInstance].feedController.lastUpdate timeIntervalSinceNow]);
   if (passedTime > self.cacheTimeout) {
     [[Appboy sharedInstance] requestFeedRefresh];
   }


### PR DESCRIPTION
I see you fixed this in the new ContentCard, but ContentCard release date is unknown, and we are using NewsFeed in production, so I think it should still be fixed for NewsFeed.