### PR TITLE
Move `CoreTelephony` to `frameworks` in Podspec

### DIFF
--- a/Appboy-iOS-SDK.podspec
+++ b/Appboy-iOS-SDK.podspec
@@ -17,11 +17,11 @@ Pod::Spec.new do |s|
 
   s.subspec 'Core' do |sc|
     sc.ios.library = 'z'
-    sc.frameworks = 'SystemConfiguration', 'QuartzCore', 'CoreText', 'WebKit'
+    sc.frameworks = 'SystemConfiguration', 'QuartzCore', 'CoreText', 'WebKit', 'CoreTelephony'
     sc.source_files = 'AppboyKit/headers/AppboyKitLibrary/*.h', 'AppboyKit/ABKIdentifierForAdvertisingProvider.m', 'AppboyKit/ABKModalWebViewController.m', 'AppboyKit/ABKNoConnectionLocalization.m', 'AppboyKit/ABKLocationManagerProvider.m'
     sc.resource = 'AppboyKit/Appboy.bundle'
     sc.vendored_libraries = 'AppboyKit/libAppboyKitLibrary.a'
-    sc.weak_framework = 'CoreTelephony', 'Social', 'Accounts', 'AdSupport', 'UserNotifications'
+    sc.weak_framework = 'Social', 'Accounts', 'AdSupport', 'UserNotifications'
   end
 
   s.subspec 'UI' do |sui|


### PR DESCRIPTION
For some reason, `CoreTelephony` is weakly linked even though it is mandatory for building the AppBoy SDK.

Otherwise build fails with CocoaPods: 
```
Ld /Users/shai.mishali/Library/Developer/Xcode/DerivedData/**-gwszrgdelbsrniendrgtooxqlgxt/Build/Products/Debug-iphonesimulator/Appboy-iOS-SDK/Appboy_iOS_SDK.framework/Appboy_iOS_SDK normal x86_64 (in target: Appboy-iOS-SDK)
    cd /Users/**********************
    export IPHONEOS_DEPLOYMENT_TARGET=9.0
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -arch x86_64 -dynamiclib -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator12.2.sdk -L/Users/shai.mishali/Library/Developer/Xcode/DerivedData/****-gwszrgdelbsrniendrgtooxqlgxt/Build/Products/Debug-iphonesimulator/Appboy-iOS-SDK -L/Users/****/Pods/Appboy-iOS-SDK/AppboyKit -F/Users/shai.mishali/Library/Developer/Xcode/DerivedData/****-gwszrgdelbsrniendrgtooxqlgxt/Build/Products/Debug-iphonesimulator/Appboy-iOS-SDK -F/Users/shai.mishali/Library/Developer/Xcode/DerivedData/****-gwszrgdelbsrniendrgtooxqlgxt/Build/Products/Debug-iphonesimulator/FLAnimatedImage -F/Users/shai.mishali/Library/Developer/Xcode/DerivedData/****-gwszrgdelbsrniendrgtooxqlgxt/Build/Products/Debug-iphonesimulator/SDWebImage -filelist /Users/shai.mishali/Library/Developer/Xcode/DerivedData/*****-gwszrgdelbsrniendrgtooxqlgxt/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/Appboy-iOS-SDK.build/Objects-normal/x86_64/Appboy_iOS_SDK.LinkFileList -install_name @rpath/Appboy_iOS_SDK.framework/Appboy_iOS_SDK -Xlinker -rpath -Xlinker @executable_path/Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -mios-simulator-version-min=9.0 -dead_strip -Xlinker -object_path_lto -Xlinker /Users/shai.mishali/Library/Developer/Xcode/DerivedData/*****-gwszrgdelbsrniendrgtooxqlgxt/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/Appboy-iOS-SDK.build/Objects-normal/x86_64/Appboy_iOS_SDK_lto.o -Xlinker -export_dynamic -Xlinker -no_deduplicate -Xlinker -objc_abi_version -Xlinker 2 -fobjc-arc -fobjc-link-runtime -fprofile-instr-generate -ObjC -lAppboyKitLibrary -lz -ObjC -framework CoreText -framework Foundation -framework QuartzCore -framework SDWebImage -framework SystemConfiguration -framework WebKit -compatibility_version 1 -current_version 1 -Xlinker -dependency_info -Xlinker /Users/shai.mishali/Library/Developer/Xcode/DerivedData/*****-gwszrgdelbsrniendrgtooxqlgxt/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/Appboy-iOS-SDK.build/Objects-normal/x86_64/Appboy_iOS_SDK_dependency_info.dat -o /Users/shai.mishali/Library/Developer/Xcode/DerivedData/*****-gwszrgdelbsrniendrgtooxqlgxt/Build/Products/Debug-iphonesimulator/Appboy-iOS-SDK/Appboy_iOS_SDK.framework/Appboy_iOS_SDK

Undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$_CTTelephonyNetworkInfo", referenced from:
      objc-class-ref in libAppboyKitLibrary.a(ABKDevice.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

![image](https://user-images.githubusercontent.com/605076/57200413-68774280-6f94-11e9-996c-c836fd315834.png)
