### PR TITLE
Cover endpoint override edge cases

### DIFF
--- a/Example/Stopwatch/OverrideEndpointDelegate.m
+++ b/Example/Stopwatch/OverrideEndpointDelegate.m
@@ -11,14 +11,18 @@
 }
 
 - (NSString *)getApiEndpoint:(NSString *)appboyApiEndpoint {
-  
-  NSMutableString *modifiedEndpoint = [appboyApiEndpoint mutableCopy];
-  NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:
-                                @"https.*\\.com" options:0 error:nil];
-  
-  [regex replaceMatchesInString:modifiedEndpoint options:0 range:NSMakeRange(0, [modifiedEndpoint length]) withTemplate:self.appboyEndpoint];
-
-  return modifiedEndpoint;
+    NSMutableString *modifiedEndpoint = [appboyApiEndpoint mutableCopy];
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:
+                                  @"https.*\\.com" options:0 error:nil];
+    
+    if (self.appboyEndpoint && modifiedEndpoint) {
+        [regex replaceMatchesInString:modifiedEndpoint options:0 range:NSMakeRange(0, [modifiedEndpoint length]) withTemplate:self.appboyEndpoint];
+        if (![modifiedEndpoint containsString:@"https://"] && ![modifiedEndpoint containsString:@"http://"]) {
+            modifiedEndpoint = [NSMutableString stringWithFormat:@"https://%@", modifiedEndpoint];
+        }
+    }
+    
+    return [modifiedEndpoint copy];
 }
 
 @end


### PR DESCRIPTION
If the `appboyApiEndpoint` passed into this delegate only includes the domain and not the https:// protocol you'll get the following error.
`[ERROR]<ABKService: 0x2802daa30>:processRequest: Connection failed! Error - unsupported URL sdk.fra-01.braze.eu/api/v3/data`

This change handles that edge case while continuing to treat `appboyApiEndpoint` that avoid it correctly.