### PR TITLE
Suppress a deprecation warning

### DIFF
--- a/AppboyUI/ABKInAppMessage/ViewControllers/ABKInAppMessageHTMLViewController.h
+++ b/AppboyUI/ABKInAppMessage/ViewControllers/ABKInAppMessageHTMLViewController.h
@@ -7,7 +7,12 @@ NS_ASSUME_NONNULL_BEGIN
 /*!
  * The UIWebView used to parse and display the HTML.
  */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 @property (weak, nonatomic) IBOutlet UIWebView *webView;
+
+#pragma clang diagnostic pop
 
 @end
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Suppress the deprecation warning `'UIWebView' is deprecated: first deprecated in iOS 12.0 - No longer supported; please adopt WKWebView.`

This is related #185 