### PR TITLE
Remove or replace `user_target_xcconfig` settings

### DIFF
--- a/Appboy-Push-Story.podspec
+++ b/Appboy-Push-Story.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'Appboy-Push-Story/AppboyPushStory.framework'
 
   # Skip this architecture to pass Pod validation since we removed the `arm64` simulator ARCH in order to use lipo later
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/Appboy-iOS-SDK.podspec
+++ b/Appboy-iOS-SDK.podspec
@@ -20,8 +20,6 @@ Pod::Spec.new do |s|
     # Skip this architecture to pass Pod validation since we removed the `arm64` simulator ARCH in order to use lipo later
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
   }
-  # Same reason as above
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 
   s.subspec 'Core' do |sc|
     sc.ios.library = 'z'

--- a/Appboy-tvOS-SDK.podspec
+++ b/Appboy-tvOS-SDK.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = 'Appboy-tvOS-SDK/AppboyTVOSKit.framework'
 
   # Skip this architecture to pass Pod validation since we removed the `arm64` simulator ARCH in order to use lipo later
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=appletvsimulator*]' => 'arm64' }
+  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=appletvsimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
It's come to our attention that there are now many pod spec authors, including you, that added this `user_target_xcconfig` setting to their pod specs.

However, doing so causes some trouble when Cocoapods installs multiple pods that use this setting but have differing values.
On `pod install` warnings like this will be emitted:

`[!] Can't merge user_target_xcconfig for pod targets: [... list of pods ...]. Singular build setting EXCLUDED_ARCHS[sdk=<...>] has different values.`

The podspec syntax reference says this attribute is "not recommended" and discourages its use.

https://guides.cocoapods.org/syntax/podspec.html#user_target_xcconfig