### PR TITLE
Preventing stackoverflow crashes 

### DIFF
--- a/AppboyUI/ABKUIUtils/ABKUIUtils.m
+++ b/AppboyUI/ABKUIUtils/ABKUIUtils.m
@@ -51,13 +51,6 @@ static NSUInteger const iPhone12ProMax = 2778.0;
 }
 
 + (UIWindow *)activeApplicationWindow {
-  if (@available(iOS 13.0, tvOS 13.0, *)) {
-    UIWindow *window = [self selectApplicationWindow:ABKUIUtils.activeWindowScene.windows];
-    if (window) {
-      return window;
-    }
-  }
-  
   return [self selectApplicationWindow:[self application].windows];
 }
 
@@ -67,17 +60,11 @@ static NSUInteger const iPhone12ProMax = 2778.0;
 
 + (BOOL)applicationStatusBarHidden {
   UIViewController *viewController = self.activeApplicationViewController;
-  while (viewController.childViewControllerForStatusBarHidden) {
-    viewController = viewController.childViewControllerForStatusBarHidden;
-  }
   return viewController.prefersStatusBarHidden;
 }
 
 + (UIStatusBarStyle)applicationStatusBarStyle {
   UIViewController *viewController = self.activeApplicationViewController;
-  while (viewController.childViewControllerForStatusBarStyle) {
-    viewController = viewController.childViewControllerForStatusBarStyle;
-  }
   return viewController.preferredStatusBarStyle;
 }
 


### PR DESCRIPTION
We were experiencing some stackoverflow crashes since the version 3.29.1 more specifically when some users were receiving in app messages. We tested these changes on our app and the in app messages are working fine.

I attached to this pull request the evidence of stackoverflow


[2020-12-13_19-25-38.3202_-0300-04ce28e3ab9656cbb9bab6edb2724a01096f7750.txt](https://github.com/Appboy/appboy-ios-sdk/files/5703348/2020-12-13_19-25-38.3202_-0300-04ce28e3ab9656cbb9bab6edb2724a01096f7750.txt)
