### PR TITLE
Add height value for iPhone 12 mini in ABKUIUtils

### DIFF
--- a/AppboyUI/ABKUIUtils/ABKUIUtils.m
+++ b/AppboyUI/ABKUIUtils/ABKUIUtils.m
@@ -2,11 +2,12 @@
 #import "ABKSDWebImageProxy.h"
 
 static NSString *const LocalizedAppboyStringNotFound = @"not found";
-static NSUInteger const iPhoneXHeight = 2436.0; // iPhone 12 mini is also this size
+static NSUInteger const iPhoneXHeight = 2436.0;
 static NSUInteger const iPhoneXRHeight = 1792.0;
 static NSUInteger const iPhoneXSMaxHeight = 2688.0;
 static NSUInteger const iPhoneXRScaledHeight = 1624.0;
 static NSUInteger const iPhone12 = 2532.0; // iPhone 12 pro is also this size
+static NSUInteger const iPhone12Mini = 2340.0;
 static NSUInteger const iPhone12ProMax = 2778.0;
 
 // Bundles
@@ -219,6 +220,7 @@ static NSString * const ABKUIPodNFBundleName = @"AppboyUI.NewsFeed.bundle";
           [[UIScreen mainScreen] nativeBounds].size.height == iPhoneXSMaxHeight ||
           [[UIScreen mainScreen] nativeBounds].size.height == iPhoneXRScaledHeight ||
           [[UIScreen mainScreen] nativeBounds].size.height == iPhone12 ||
+          [[UIScreen mainScreen] nativeBounds].size.height == iPhone12Mini ||
           [[UIScreen mainScreen] nativeBounds].size.height == iPhone12ProMax);
 }
 


### PR DESCRIPTION
Hi, I have an issue when using ABKInAppMessageFullViewController on iPhone 12 mini.
In the screenshot, the close button is hidden in the status bar.

![Screen Shot 2020-12-18 at 10 38 03 AM](https://user-images.githubusercontent.com/3113810/102563845-8ec40480-411d-11eb-9d0b-62fbf43e82b7.png)

So I debugged your SDK and found some issue about incorrect height in ABKUIUtils.
I added code to the ABKUIUtils, to return the correct value in isNotchedPhone method when using iPhone 12 mini.