### PR TITLE
Add missing « DEFINES_MODULE »

### DIFF
--- a/Appboy-iOS-SDK.podspec
+++ b/Appboy-iOS-SDK.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'AppboyKit/**/*.*'
   s.default_subspec = 'UI'
 
-  s.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
+  s.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-ObjC', 'DEFINES_MODULE' => 'YES' }
 
   s.subspec 'Core' do |sc|
     sc.ios.library = 'z'


### PR DESCRIPTION
This is needed to include the SDK without to have to specify `:modular_headers => true`