### PR TITLE
Enable subclass in Swift

### DIFF
--- a/AppboyUI/ABKContentCards/ViewControllers/ABKContentCardsTableViewController.h
+++ b/AppboyUI/ABKContentCards/ViewControllers/ABKContentCardsTableViewController.h
@@ -6,6 +6,9 @@
 
 @interface ABKContentCardsTableViewController : UITableViewController
 
+- (id)initWithCoder:(NSCoder *)decoder NS_DESIGNATED_INITIALIZER;
+- (id)init NS_DESIGNATED_INITIALIZER;
+
 /*!
  * UI elements which are used in the Content Cards table view. You can find them in the Content Cards Storyboard.
  */


### PR DESCRIPTION
Trying to subclass ABKContentCardsTableViewController in Swift results in the compiler error: Must call a designated initializer of the superclass 'ABKContentCardsTableViewController'

Swift is not properly inferring the designated initializers, so trying to call super.init() results in an error, as does calling super.init(delegate:). Placing the signatures for init and initWithCoder: in the public header and marking them with NS_DESIGNATED_INITIALIZER seems to do the trick.